### PR TITLE
feat: refactor common auth patterns

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,5 +8,11 @@
 
 Reusable workflows for making reusable workflows
 
-* [auto-doc](../README-auto-doc.md)
-* [release](/README-release.md)
+- [auto-doc](/README-auto-doc.md)
+- [release](/README-release.md)
+
+Reusable actions
+
+- `cloud-auth` for GCP and Azure
+- `k8s-auth` for GKE and AKS
+- `docker-auth` for GCR or ACR

--- a/.github/actions/cloud-auth/action.yml
+++ b/.github/actions/cloud-auth/action.yml
@@ -1,0 +1,45 @@
+name: Entur/Meta/CloudAuth
+inputs:
+  environment:
+    description: "The target environment"
+    required: true
+    type: string
+  cloud_provider:
+    description: "Which repository to use. GCP/Azure"
+    type: string
+    default: "GCP"
+  token_format:
+    description: |-
+      Output format for the generated authentication token. For OAuth 2.0 access
+      tokens, specify "access_token". For OIDC tokens, specify "id_token". To
+      skip token generation, leave this value empty.
+    default: ""
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - id: set-env
+      shell: bash
+      run: |
+        echo "GHA_CLOUD_AUTH_CLOUD_PROVIDER=${{ inputs.cloud_provider }}" >> $GITHUB_ENV
+        echo "GHA_CLOUD_AUTH_TOKEN_FORMAT=${{ inputs.token_format }}" >> $GITHUB_ENV
+    - id: verify-cloud-provider
+      if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER != 'GCP' && env.GHA_CLOUD_AUTH_CLOUD_PROVIDER != 'Azure'
+      shell: bash
+      run: |
+        echo "cloud_provider can only be GCP or Azure"
+        exit 1
+    - id: login-gcp
+      if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER == 'GCP'
+      uses: google-github-actions/auth@v2.1.2
+      with:
+        workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.SERVICE_ACCOUNT }}
+        token_format: ${{ env.GHA_CLOUD_AUTH_TOKEN_FORMAT }}
+    - id: login-azure
+      if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER == 'Azure'
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ vars.AZURE_CLIENT_ID }}
+        tenant-id: ${{ vars.AZURE_TENANT_ID }}
+        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}

--- a/.github/actions/cloud-auth/action.yml
+++ b/.github/actions/cloud-auth/action.yml
@@ -8,20 +8,10 @@ inputs:
     description: "Which repository to use. GCP/Azure"
     type: string
     default: "GCP"
-  token_format:
-    description: |-
-      Output format for the generated authentication token. For OAuth 2.0 access
-      tokens, specify "access_token". For OIDC tokens, specify "id_token". To
-      skip token generation, leave this value empty.
-    default: ""
-    required: false
   workload_identity_provider:
     type: string
     default: ""
   service_account:
-    type: string
-    default: ""
-  gha_cloud_auth_token_format:
     type: string
     default: ""
   azure_client_id:
@@ -41,7 +31,6 @@ runs:
       shell: bash
       run: |
         echo "GHA_CLOUD_AUTH_CLOUD_PROVIDER=${{ inputs.cloud_provider }}" >> $GITHUB_ENV
-        echo "GHA_CLOUD_AUTH_TOKEN_FORMAT=${{ inputs.token_format }}" >> $GITHUB_ENV
     - id: verify-cloud-provider
       if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER != 'GCP' && env.GHA_CLOUD_AUTH_CLOUD_PROVIDER != 'Azure'
       shell: bash
@@ -54,7 +43,6 @@ runs:
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
-        token_format: ${{ inputs.gha_cloud_auth_token_format }}
     - id: login-azure
       if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER == 'Azure'
       uses: Azure/login@v2

--- a/.github/actions/cloud-auth/action.yml
+++ b/.github/actions/cloud-auth/action.yml
@@ -33,9 +33,6 @@ inputs:
   azure_subscription_id:
     type: string
     default: ""
-  azure_subscription_id:
-    type: string
-    default: ""
 
 runs:
   using: "composite"

--- a/.github/actions/cloud-auth/action.yml
+++ b/.github/actions/cloud-auth/action.yml
@@ -15,6 +15,28 @@ inputs:
       skip token generation, leave this value empty.
     default: ""
     required: false
+  workload_identity_provider:
+    type: string
+    default: ""
+  service_account:
+    type: string
+    default: ""
+  gha_cloud_auth_token_format:
+    type: string
+    default: ""
+  azure_client_id:
+    type: string
+    default: ""
+  azure_tenant_id:
+    type: string
+    default: ""
+  azure_subscription_id:
+    type: string
+    default: ""
+  azure_subscription_id:
+    type: string
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -33,13 +55,13 @@ runs:
       if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER == 'GCP'
       uses: google-github-actions/auth@v2.1.2
       with:
-        workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.SERVICE_ACCOUNT }}
-        token_format: ${{ env.GHA_CLOUD_AUTH_TOKEN_FORMAT }}
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
+        token_format: ${{ inputs.gha_cloud_auth_token_format }}
     - id: login-azure
       if: env.GHA_CLOUD_AUTH_CLOUD_PROVIDER == 'Azure'
       uses: Azure/login@v2
       with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}

--- a/.github/actions/docker-auth/action.yml
+++ b/.github/actions/docker-auth/action.yml
@@ -1,0 +1,76 @@
+name: Entur/Meta/DockerAuth
+inputs:
+  environment:
+    description: "The target environment"
+    required: true
+    type: string
+  cloud_provider:
+    description: "Which repository to use. GCP/Azure"
+    type: string
+    default: "GCP"
+  token_format:
+    description: |-
+      Output format for the generated authentication token. For OAuth 2.0 access
+      tokens, specify "access_token". For OIDC tokens, specify "id_token". To
+      skip token generation, leave this value empty.
+    default: ""
+    required: false
+  workload_identity_provider:
+    type: string
+    default: ""
+  service_account:
+    type: string
+    default: ""
+  gha_cloud_auth_token_format:
+    type: string
+    default: ""
+  azure_client_id:
+    type: string
+    default: ""
+  azure_tenant_id:
+    type: string
+    default: ""
+  azure_subscription_id:
+    type: string
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - id: set-env
+      shell: bash
+      run: |
+        echo "GHA_DOCKER_AUTH_CLOUD_PROVIDER=${{ inputs.cloud_provider }}" >> $GITHUB_ENV
+        echo "GHA_DOCKER_AUTH_TOKEN_FORMAT=${{ inputs.token_format }}" >> $GITHUB_ENV
+    - id: verify-cloud-provider
+      if: env.GHA_DOCKER_AUTH_CLOUD_PROVIDER != 'GCP' && env.GHA_DOCKER_AUTH_CLOUD_PROVIDER != 'Azure'
+      shell: bash
+      run: |
+        echo "cloud_provider can only be GCP or Azure"
+        exit 1
+    - id: login-gcp
+      if: env.GHA_DOCKER_AUTH_CLOUD_PROVIDER == 'GCP'
+      uses: google-github-actions/auth@v2.1.2
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
+        token_format: "access_token"
+    - id: login-gcr
+      uses: docker/login-action@v3.1.0
+      if: inputs.cloud_provider == 'GCP'
+      with:
+        registry: eu.gcr.io
+        username: oauth2accesstoken
+        password: ${{ steps.login-gcp.outputs.access_token }}
+    - id: login-azure
+      if: env.GHA_DOCKER_AUTH_CLOUD_PROVIDER == 'Azure'
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
+    - id: login-acr
+      if: env.GHA_DOCKER_AUTH_CLOUD_PROVIDER == 'Azure'
+      shell: bash
+      run: |
+        az acr login --name acrentur001

--- a/.github/actions/k8s-auth/action.yml
+++ b/.github/actions/k8s-auth/action.yml
@@ -1,0 +1,45 @@
+name: Entur/Meta/KubernetesAuth
+inputs:
+  environment:
+    description: "The target environment"
+    required: true
+    type: string
+  cloud_provider:
+    description: "Which repository to use. GCP/Azure"
+    type: string
+    default: "GCP"
+runs:
+  using: "composite"
+  steps:
+    - id: set-env
+      shell: bash
+      run: |
+        echo "GHA_KUBERNETES_AUTH_CLOUD_PROVIDER=${{ inputs.cloud_provider }}" >> $GITHUB_ENV
+    - id: verify-cloud-provider
+      if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER != 'GCP' && env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER != 'Azure'
+      shell: bash
+      run: |
+        echo "cloud_provider can only be GCP or Azure"
+        exit 1
+    - id: get-credentials-gcp
+      if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER == 'GCP'
+      uses: google-github-actions/get-gke-credentials@v1
+      with:
+        project_id: "ent-kub-${{inputs.environment}}" # TODO: fix jp
+        cluster_name: "kub-ent-${{inputs.environment}}-001" # TODO: fix jp
+        location: "europe-west1" # TODO: fix jp
+    - id: kubelogin-azure
+      if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER == 'Azure'
+      uses: azure/use-kubelogin@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        kubelogin-version: "latest"
+    - id: set-context-azure
+      if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER == 'Azure'
+      uses: azure/aks-set-context@v3
+      with:
+        resource-group: ${{ vars.AZURE_CLUSTER_RESOURCE_GROUP }}
+        cluster-name: ${{ vars.AZURE_CLUSTER_NAME }}
+        admin: false
+        use-kubelogin: true

--- a/.github/actions/k8s-auth/action.yml
+++ b/.github/actions/k8s-auth/action.yml
@@ -4,6 +4,9 @@ inputs:
     description: "The target environment"
     required: true
     type: string
+  github_token:
+    type: string
+    required: true
   cloud_provider:
     description: "Which repository to use. GCP/Azure"
     type: string
@@ -14,6 +17,7 @@ inputs:
   azure_cluster_name:
     type: string
     default: ""
+
 runs:
   using: "composite"
   steps:
@@ -38,7 +42,7 @@ runs:
       if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER == 'Azure'
       uses: azure/use-kubelogin@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         kubelogin-version: "latest"
     - id: set-context-azure

--- a/.github/actions/k8s-auth/action.yml
+++ b/.github/actions/k8s-auth/action.yml
@@ -8,6 +8,12 @@ inputs:
     description: "Which repository to use. GCP/Azure"
     type: string
     default: "GCP"
+  azure_cluster_resource_group:
+    type: string
+    default: ""
+  azure_cluster_name:
+    type: string
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -39,7 +45,7 @@ runs:
       if: env.GHA_KUBERNETES_AUTH_CLOUD_PROVIDER == 'Azure'
       uses: azure/aks-set-context@v3
       with:
-        resource-group: ${{ vars.AZURE_CLUSTER_RESOURCE_GROUP }}
-        cluster-name: ${{ vars.AZURE_CLUSTER_NAME }}
+        resource-group: ${{ inputs.azure_cluster_resource_group }}
+        cluster-name: ${{ inputs.azure_cluster_name }}
         admin: false
         use-kubelogin: true


### PR DESCRIPTION
Provide (intentionally undocumented)
- cloud-auth
- k8s-auth
- docker-auth
So auth is easier for `gha-terraform` `gha-docker` and `gha-helm`