### PR TITLE
ci: add tests for azure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,28 +41,28 @@ jobs:
 
   test-local-actions-azure:
     runs-on: ubuntu-24.04
-    environment: dev
+    environment: az-dev
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cloud-auth
         with:
-          environment: dev
+          environment: az-dev
           cloud_provider: az
           azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - uses: ./.github/actions/k8s-auth
         with:
-          environment: dev
+          environment: az-dev
           cloud_provider: az
           azure_cluster_resource_group: ${{ vars.AZURE_CLUSTER_RESOURCE_GROUP }}
           azure_cluster_name: ${{ vars.AZURE_CLUSTER_NAME }}
           azure_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/docker-auth
         with:
-          environment: dev
+          environment: az-dev
           cloud_provider: az
           azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       workflow_file: .github/workflows/release.yml
       readme_file: README-release.md
 
-  test-local-actions:
+  test-local-actions-gcp:
     runs-on: ubuntu-24.04
     environment: dev
     permissions:
@@ -38,3 +38,32 @@ jobs:
           cloud_provider: gcp
           gcp_workload_identity_provider: ${{ vars.CI_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.CI_SERVICE_ACCOUNT }}
+
+  test-local-actions-azure:
+    runs-on: ubuntu-24.04
+    environment: dev
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cloud-auth
+        with:
+          environment: dev
+          cloud_provider: az
+          azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: ./.github/actions/k8s-auth
+        with:
+          environment: dev
+          cloud_provider: az
+          azure_cluster_resource_group: ${{ vars.AZURE_CLUSTER_RESOURCE_GROUP }}
+          azure_cluster_name: ${{ vars.AZURE_CLUSTER_NAME }}
+          azure_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/docker-auth
+        with:
+          environment: dev
+          cloud_provider: az
+          azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
This will make the tests for actions running against Azure in addition to the already existing one running against GCP.
To have running tests is a prerequisite before updating the actions (CLOUD-2104)