### PR TITLE
feat: Add input parameters to choose branch and author

### DIFF
--- a/.github/workflows/auto-doc.yml
+++ b/.github/workflows/auto-doc.yml
@@ -3,6 +3,13 @@ name: Entur/Meta/Doc
 on:
   workflow_call:
     inputs:
+      branch:
+        description: Name of branch to push commit to
+        type: string
+      commit_default_author:
+        type: string
+        description: "How to select author of the commit. Options: github_actor, user_info, github_actions"
+        default: "github_actor"
       workflow_file:
         description: Path to the workflow file
         type: string
@@ -22,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ inputs.branch || github.event.pull_request.head.ref }}
       - uses: tj-actions/auto-doc@b10ceedffd794ec29a8fa8700529f40c1b64a951 # v3.6.0
         with:
           filename: ${{ inputs.workflow_file }}
@@ -43,6 +50,7 @@ jobs:
       - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
+          default_author: ${{ inputs.commit_default_author }}
           message: "docs: Update workflow documentation"
           add: ${{ inputs.readme_file }}
           pull: "--ff-only"

--- a/.github/workflows/auto-doc.yml
+++ b/.github/workflows/auto-doc.yml
@@ -3,7 +3,7 @@ name: Entur/Meta/Doc
 on:
   workflow_call:
     inputs:
-      branch:
+      target_branch:
         description: Name of branch to push commit to
         type: string
       commit_default_author:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Intellij IDEA
+.idea

--- a/README-auto-doc.md
+++ b/README-auto-doc.md
@@ -8,11 +8,13 @@ Uses https://github.com/marketplace/actions/auto-doc
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|                                     INPUT                                     |  TYPE  | REQUIRED | DEFAULT |        DESCRIPTION        |
-|-------------------------------------------------------------------------------|--------|----------|---------|---------------------------|
-|       <a name="input_readme_file"></a>[readme_file](#input_readme_file)       | string |  false   |         |  Path to the output file  |
-| <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes) | number |  false   |   `5`   |  Job timeout in minutes   |
-|    <a name="input_workflow_file"></a>[workflow_file](#input_workflow_file)    | string |  false   |         | Path to the workflow file |
+|                                              INPUT                                              |  TYPE  | REQUIRED |     DEFAULT      |                                          DESCRIPTION                                          |
+|-------------------------------------------------------------------------------------------------|--------|----------|------------------|-----------------------------------------------------------------------------------------------|
+|                       <a name="input_branch"></a>[branch](#input_branch)                        | string |  false   |                  |                             Name of branch to push <br>commit to                              |
+| <a name="input_commit_default_author"></a>[commit_default_author](#input_commit_default_author) | string |  false   | `"github_actor"` | How to select author of <br>the commit. Options: github_actor, user_info, <br>github_actions  |
+|                <a name="input_readme_file"></a>[readme_file](#input_readme_file)                | string |  false   |                  |                                    Path to the output file                                    |
+|          <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)          | number |  false   |       `5`        |                                    Job timeout in minutes                                     |
+|             <a name="input_workflow_file"></a>[workflow_file](#input_workflow_file)             | string |  false   |                  |                                   Path to the workflow file                                   |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/README-auto-doc.md
+++ b/README-auto-doc.md
@@ -10,9 +10,9 @@ Uses https://github.com/marketplace/actions/auto-doc
 
 |                                              INPUT                                              |  TYPE  | REQUIRED |     DEFAULT      |                                          DESCRIPTION                                          |
 |-------------------------------------------------------------------------------------------------|--------|----------|------------------|-----------------------------------------------------------------------------------------------|
-|                       <a name="input_branch"></a>[branch](#input_branch)                        | string |  false   |                  |                             Name of branch to push <br>commit to                              |
 | <a name="input_commit_default_author"></a>[commit_default_author](#input_commit_default_author) | string |  false   | `"github_actor"` | How to select author of <br>the commit. Options: github_actor, user_info, <br>github_actions  |
 |                <a name="input_readme_file"></a>[readme_file](#input_readme_file)                | string |  false   |                  |                                    Path to the output file                                    |
+|             <a name="input_target_branch"></a>[target_branch](#input_target_branch)             | string |  false   |                  |                             Name of branch to push <br>commit to                              |
 |          <a name="input_timeout_minutes"></a>[timeout_minutes](#input_timeout_minutes)          | number |  false   |       `5`        |                                    Job timeout in minutes                                     |
 |             <a name="input_workflow_file"></a>[workflow_file](#input_workflow_file)             | string |  false   |                  |                                   Path to the workflow file                                   |
 


### PR DESCRIPTION
This way, I can have a cd.yml pipeline looking something like this:

```yml
name: create release
on:
  push:
    branches:
      - main
permissions:
  pull-requests: write
  contents: write
  issues: write
jobs:
  release:
    uses: entur/gha-meta/.github/workflows/release.yml@v1
  update-doc:
    needs: release
    uses: entur/gha-meta/.github/workflows/auto-doc.yml@v1
    with:
      commit_default_author: 'github_actions'
      target_branch: 'release-please--branches--main'
      workflow_file: .github/workflows/autodoc.yml
      readme_file: README-autodoc.md
```

This adds autodoc based changes as commits on the release please branch. This has the advantage also that changes to documentation is not done until the new version is released. It is not tested very thoroughly, but it works in the simple case: https://github.com/entur/gha-api/pull/114