### PR TITLE
fix: Don't collect GHA duration data to send to PostHog.

### DIFF
--- a/.github/actions/posthog/action.yml
+++ b/.github/actions/posthog/action.yml
@@ -90,10 +90,7 @@ runs:
       uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650  # v1.2.0
       continue-on-error: true
       with:
-        capture-job-durations: 'true'
-        capture-run-duration: 'true'
         event: ${{ inputs.workflow_name }}
-        github-token: ${{ github.token }}
         posthog-api-host: https://eu.i.posthog.com
         posthog-token: ${{ inputs.api_key }}
         properties: ${{ steps.build_properties.outputs.properties }}


### PR DESCRIPTION
Collecting data on action duration requires the PostHog action to have a github token with 'actions: read' rights. If this action is called from another workflow that sets 'actions: none' (or doesn't set anything, which defaults to no permissions), the whole pipeline won't start. Not collecting job duration seems to be the safest way out for now.